### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
  before_action :authenticate_user!, only: :new
 
  def index
+  @items = Item.includes(:user).order("created_at DESC")
  end
 
  def new
@@ -16,8 +17,6 @@ class ItemsController < ApplicationController
     render :new, status: :unprocessable_entity
    end
  end
-
-
 
  private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,13 +128,12 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 【購入機能実装後に実装します】商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
@@ -143,23 +142,21 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_condition.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
+      <% unless Item.exists?%>
+       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
@@ -176,8 +173,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
出品した商品がトップページで見えるようにしました。
また、出品商品がない場合は、ダミー商品を見せるようにしました。

# Why
furimaアプリの出品商品一覧表示機能実装のため。

# 提出動画
商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/3c837090511c4bb78147ea5f95246fe9

商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/3d7670deeabf98af21de5fbdbcbe4e64
